### PR TITLE
Fix layout baseurl and typos

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
     {% include header.html %}
     <div class="container">
         <div class="inner-container">
-            {{ content | prepend: site.baseurl }}
+            {{ content }}
         </div>
     </div>
     {% include footer.html %}

--- a/android.markdown
+++ b/android.markdown
@@ -21,7 +21,7 @@ Click the link from the invite (in previous step) or visit this URL on your mobi
 
 You are done! You can now find KnowU app in your phone like a regular app.
 
-![KnowU installed on Anrdoid](/media/android-installed-example.jpg)
+![KnowU installed on Android](/media/android-installed-example.jpg)
 
 ## Updates
 When new versions are released to the KnowU app you will be able to update the app via Google Play. Similar way when you installed the app in the first place. Note that the application name might show as *app.mxm.knowu (unreviewed)* instead of just KnowU. You can also just navigate directly here [https://play.google.com/store/apps/details?id=app.mxm.knowu&hl=en-US&ah=AiHcSzx6-s7YxPO-9JYLhIVHYDE](https://play.google.com/store/apps/details?id=app.mxm.knowu&hl=en-US&ah=AiHcSzx6-s7YxPO-9JYLhIVHYDE) to update the app.

--- a/ios.markdown
+++ b/ios.markdown
@@ -8,12 +8,12 @@ permalink: /ios/
 To get an invitation from KnowU, please submit your details using [this form](https://knowu.app/join/). Once you receive a confirmation email at the address you provided, you can move on to Step 2.
 
 ## 2nd step
-You need to install TestFligh application on your phone from [App Store](https://apps.apple.com/us/app/testflight/id899247664). This is normal process and pre-requirement for apps that have not yet been publicly published on App Store.
+You need to install the TestFlight application on your phone from [App Store](https://apps.apple.com/us/app/testflight/id899247664). This is the normal process and a prerequisite for apps that have not yet been publicly published on the App Store.
 
 [![TestFlight App](/media/testflight-icon.png)](https://apps.apple.com/us/app/testflight/id899247664)
 
 ## 3rd step
-Open your TestFligh app on your phone and you should see KnowU application there. Install it.
+Open your TestFlight app on your phone and you should see the KnowU application there. Install it.
 
 ![Install KnowU via TestFlight app](/media/testflight-example.png)
 


### PR DESCRIPTION
## Summary
- fix layout bug that added baseurl to page content
- correct typos in mobile installation guides

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b4042e44832d8061a2ebc08e0260